### PR TITLE
Fix failing build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 8.10.0
+- "lts/*"
 before_script: 'npm install -g zapier-platform-cli'
 script: 'zapier test'
 notifications:


### PR DESCRIPTION
### Motivation

Set node to LTS version to be able to install Zapier CLI, which requires Node >=10.

